### PR TITLE
Implement Travis CI with coala

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,0 +1,27 @@
+[default]
+bears = SpaceConsistencyBear, LineLengthBear
+files = **.html, **.css, **.js, **.md
+ignore = **.min.css, **.min.js, _site/**
+max_line_length = 300
+use_spaces = True
+
+[html]
+bears = HTMLLintBear, BootLintBear
+files = **.html
+htmllint_ignore = indentation, optional_tag, concerns_separation, capitalization
+
+[css]
+bears = PHPCodeSnifferBear
+files = **.css
+ignore = **.min.css
+
+[js]
+bears = JSHintBear
+files = **.js
+ignore = **.min.js
+environment_jquery = True
+javascript_strictness = implied
+
+[md]
+bears = MarkdownBear
+files = **.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: trusty
+
+language: generic
+
+cache:
+  directories:
+  - .coala-cache
+
+services: docker
+
+
+script:
+  - >
+    docker run --volume=$(pwd)/.coala-cache:/root/.local/share/coala --volume=$(pwd):/app --workdir=/app coala/base:0.11 /bin/bash -c
+    "coala --apply-patches --no-orig;
+    coala --non-interactive"


### PR DESCRIPTION
Coala can be run on Travis CI to check code quality, which will ensure
that the code quality is well maintained in the future as well, hence
giving the project a good lifeline. The docker image will be cached
so as to ensure more quicker Travis Ci builds.

Fixes #3 

Link to test my build: https://travis-ci.org/abishekvashok/labyrinth/builds/314350475

(**Note:** the build is failing because the code is not properly lint.)

After merging this PR please enable Travis Ci builds for this repository:
https://travis-ci.org/fossasia/labyrinth/builds/314350475