### PR TITLE
Fix override bug of goal tile

### DIFF
--- a/js/tiles.js
+++ b/js/tiles.js
@@ -201,8 +201,12 @@ const door = {
       this.wallRight = this.createImage("tiles/rooms/door/right.svg");
       this.ground = this.createImage("tiles/rooms/floor/goal.svg");
     },
+    /* Override the function */
     visit: function() {
       alert("You have won the game");
+      this.wallTop.show();
+      this.wallRight.show();
+      this.ground.show();
     },
   }),
 };


### PR DESCRIPTION
This pull request is related to issue #52 

I modified the labyrinth, you can test my changes here:
http://rawgit.com/abishekvashok/labyrinth/master/index.html
<!-- Please replace USERNAME with your GitHub user name and
     BRANCH-NAME with your branch name e.g. master -->


<!-- please summarize the problem you faced -->
The problem I want to solve is the overiding of the visit function which prevented the goal tile from rendering.

<!-- Please summarize the solution you chose -->
My solution for the problem is:
The goal tile's visit function was overridden which prevented it from
firing up, added the overwritten code that would have been overwritten
to the visit attribute which would be explicitly obeyed now.

![screenshot_20171229_190352](https://user-images.githubusercontent.com/8947010/34441099-97e316a4-ecdf-11e7-99ec-129284db221c.png)


