### PR TITLE
[Please comment] Add GCI Tasks

### DIFF
--- a/tasks/add-a-functionality.md
+++ b/tasks/add-a-functionality.md
@@ -1,0 +1,34 @@
+
+
+---
+
+# Labyrinth: Add a Functionality
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth.
+To make the game more interesting, please add a place which can only be entered if something else was done before,
+e.g. a door with a key to find, a troll and a meal to prepare, a river and a boat to build, ... .
+
+Requirements:
+- Create a picture for the item you need (key/boat/...)
+- Add a tile wich fits to the item
+- Add the behavior of the tile to the [tiles.js](https://github.com/fossasia/labyrinth/blob/master/js/tiles.js) file.
+- The pictures MUST be your own work.
+- Place tile and dependency into the labyrinth.
+
+Expected Outcome:
+- a merged pull request
+- two tiles are added to the labyrinth
+- the tiles are reachable
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [X] User Interface
+- [ ] Documentation / Training
+- [ ] Quality Assurance
+- [ ] Outreach / Research

--- a/tasks/cooperate-on-a-pull-request.md
+++ b/tasks/cooperate-on-a-pull-request.md
@@ -1,0 +1,33 @@
+
+
+---
+
+# Labyrinth: Cooperate on a Pull Request
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth.
+To train online cooperation, please cooperate on a pull request with an other student and solve an issue together.
+
+Requirements:
+- There is an [issue](https://github.com/fossasia/labyrinth/issues) which you want to solve
+- You find an other person who likes to cooperate with you [in the chat](https://gitter.im/fossasia/labyrinth).
+- Both you and the other person contribute to the pull request - at least one commit by you and the other person.
+
+Expected Outcome:
+- A merged pull request with at least two commits: one by you, one by another person (GCI or not): Post a link here
+- We see that you and the other person agreed to cooperate: Post a link here of your agreement
+
+Hints:
+- You can either 
+  - create a pull request to the branch of an other person and [compare across forks](https://github.com/fossasia/labyrinth/compare)
+  - or give the other person write access to your repository "Settings" -> "Collaborators and Teams"
+- You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [ ] Code
+- [ ] User Interface
+- [X] Documentation / Training
+- [ ] Quality Assurance
+- [ ] Outreach / Research

--- a/tasks/create-a-hand-drawn-landscape.md
+++ b/tasks/create-a-hand-drawn-landscape.md
@@ -1,0 +1,34 @@
+https://codein.withgoogle.com/dashboard/tasks/5576637804445696/
+
+---
+
+# Labyrinth: Create a hand-drawn landscape
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. Please add a new landscape which is hand-drawn.
+
+Requirements:
+- Download and install [Inkscape](http://inkscape.org/)
+- Create tiles with the same dimensions as those which are there. Ways of his tile must end at the middle of the edges. These tiles must be hand-drawn. A work-flow could be:
+  1. draw one tile on a sheet of paper
+  2. scan it or photograph it
+  3. make the unnecessary pixels/sections transparent - you can do that by using a PNG file or by clipping in Inkscape.
+- Add the tiles to the labyrinth, so they are reachable. Please create a small portion of the labyrinth with them to make it more exciting. You may get inspiration from other parts of the labyrinth.
+- Create a pull-request and have it merged and reviewed.
+
+Expected outcome:
+- The hand-drawn tiles are added to the [tiles folder](https://github.com/fossasia/labyrinth/tree/master/tiles/)
+- An implementation of their behavior (how they can be entered and left, ...) is added to the [tiles file](https://github.com/fossasia/labyrinth/blob/master/js/tiles.js).
+- A small landscape with the tiles is part of the [larger labyrinth](https://github.com/fossasia/labyrinth) and reachable.
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [ ] User Interface
+- [ ] Documentation / Training
+- [ ] Quality Assurance
+- [X] Outreach / Research

--- a/tasks/create-a-new-level.md
+++ b/tasks/create-a-new-level.md
@@ -1,0 +1,29 @@
+
+
+---
+
+# Labyrinth: Add a level
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth.
+To extent the labyrinth, please add a new level.
+
+Requirements:
+- The level should be at least 7x7 tiles big. You do not need to create a compact level. You can also make long walks.
+- The level is reachable by completing the level before.
+
+Expected Outcome:
+- A new level is added to the [levels.js](https://github.com/fossasia/labyrinth/blob/master/js/levels.js) file.
+- players can reach the level and play it
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [X] User Interface
+- [ ] Documentation / Training
+- [ ] Quality Assurance
+- [ ] Outreach / Research

--- a/tasks/create-animated-tile.md
+++ b/tasks/create-animated-tile.md
@@ -1,0 +1,33 @@
+https://codein.withgoogle.com/dashboard/tasks/5369748894253056/
+
+---
+
+# Labyrinth: Create an animated tile
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. Please, create a tile which is interactive. 
+
+Requirements:
+
+- Download and install [Inkscape](http://inkscape.org/)
+- Create a tile with the same dimensions as those which are there. Ways of his tile must end at the middle of the edges.
+- Use CSS to animate the tile in a way: Bird flapping/oven cooking/water dropping, ... 
+- While editing the game you may have ideas for improvement - add them as [github issue](https://github.com/fossasia/flappy-svg/issues).
+- create a pull-request and have it merged and reviewed
+
+Expected Outcome:
+- An SVG tile was added to the [tiles folder](https://github.com/fossasia/labyrinth/tree/master/tiles/)
+- An implementation of that tile was added to the [tiles file](https://github.com/fossasia/labyrinth/blob/master/js/tiles.js)
+- The tile is part of the [larger labyrinth](https://github.com/fossasia/labyrinth) and reachable.
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [X] User Interface
+- [ ] Documentation / Training
+- [ ] Quality Assurance
+- [ ] Outreach / Research

--- a/tasks/create-character.md
+++ b/tasks/create-character.md
@@ -15,7 +15,7 @@ Requirements:
 Expected Outcome:
 - a merged pull request
 - a new character is added to the game
-- tha character can be chosen to play with
+- the character can be chosen to play with
 
 Hints:
 - If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.

--- a/tasks/create-character.md
+++ b/tasks/create-character.md
@@ -1,0 +1,31 @@
+
+
+---
+
+# Labyrinth: Add a character
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. To allow players to choose between different characters, please add a character.
+
+Requirements:
+- Create an SVG or PNG character (200x200 pixels) for the game
+- Add the character to the characters folder **TODO: Link**
+- Modify the characters.js file **TODO: Link** to load your character.
+- The character MUST be your own work.
+
+Expected Outcome:
+- a merged pull request
+- a new character is added to the game
+- tha character can be chosen to play with
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [X] User Interface
+- [ ] Documentation / Training
+- [ ] Quality Assurance
+- [ ] Outreach / Research

--- a/tasks/create-tiles-for-landscape.md
+++ b/tasks/create-tiles-for-landscape.md
@@ -1,0 +1,31 @@
+https://codein.withgoogle.com/dashboard/tasks/5178639761014784/
+
+---
+
+# Labyrinth: Create tiles for a landscape
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. Please add a new landscape.
+
+Requirements:
+- Download and install [Inkscape](http://inkscape.org/)
+- Create tiles with the same dimensions as those which are there. Ways of his tile must end at the middle of the edges.
+- Add the tiles to the labyrinth, so they are reachable. Please create a small portion of the labyrinth with them to make it more exciting. You may get inspiration from other parts of the labyinth.
+- create a pull-request and have it merged and reviewed
+
+Expected outcome:
+- The tiles are added to the [tiles folder](https://github.com/fossasia/labyrinth/tree/master/tiles/)
+- An implementation of their behavior (how they can be entered and left, ...) is added to the [tiles file](https://github.com/fossasia/labyrinth/blob/master/js/tiles.js).
+- A small landscape with the tiles is part of the [larger labyrinth](https://github.com/fossasia/labyrinth) and reachable.
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [X] User Interface
+- [ ] Documentation / Training
+- [ ] Quality Assurance
+- [ ] Outreach / Research

--- a/tasks/document-how-to-contribute.md
+++ b/tasks/document-how-to-contribute.md
@@ -1,0 +1,31 @@
+https://codein.withgoogle.com/dashboard/tasks/6479191560159232/
+
+---
+
+# Labyrinth: Document how to contribute
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. Please make it easier to contribute by adding the necessary documentation.
+
+Requirements:
+- Add a new [issue](https://github.com/fossasia/labyrinth/issues) about which parts of the documentation you would like to contribute to and what the problem is.
+- Discuss the issue
+- Solve the issue alone or with others with one or more pull-requests.
+
+Expected Outcome:
+- Please post the link to the solved issue.
+- There must be one commit in a pull request for this issue which is attributed to you.
+- Make sure, you are assigned to work on this issue.
+
+Hints:
+- If the issue is too big, split it up in smaller parts.
+- You must make a substantial contribution to the documentation, not just fixing a misspelling but fixing multiple misunderstandings or adding a new documented way to contribute. Please discuss whether this is a substantial contribution in the issue before you submit.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [ ] Code
+- [ ] User Interface
+- [X] Documentation / Training
+- [ ] Quality Assurance
+- [ ] Outreach / Research

--- a/tasks/enable-a-new-gci-task.md
+++ b/tasks/enable-a-new-gci-task.md
@@ -1,0 +1,37 @@
+https://codein.withgoogle.com/dashboard/tasks/5680981551874048/
+
+---
+
+# Labyrinth: Enable a new GCI task
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth.
+We have [a lot of tasks](https://github.com/fossasia/labyrinth/tree/master/tasks) you can do.
+However, some tasks are not posted to the system because there needs to be done some work before.
+Help us post the new tasks!
+
+Optional:
+- Create a new GCI task in the [tasks directory](https://github.com/fossasia/labyrinth/tree/master/tasks).
+
+Requirements:
+- Create an issue or find one for the task you want to enable.
+- Ask what needs to be done to post the task (This should be a bullet list in the issue description).
+- Create at least one pull request to resolve the issue.
+
+Expected outcome:
+- At least one pull request is merged
+- The issue is resolved and a mentor agrees to post the task.
+- All issues resulting from your pull-requests are resolved. This is important: You may create new issues and we tend to merge fast and allow several pull requests to be submitted for one issue
+
+Hints:
+- [Example Issue](https://github.com/fossasia/labyrinth/issues/68)
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [X] User Interface
+- [X] Documentation / Training
+- [ ] Quality Assurance
+- [X] Outreach / Research

--- a/tasks/improve-code-quality.md
+++ b/tasks/improve-code-quality.md
@@ -1,0 +1,30 @@
+# Labyrinth: Improve the Code Quality
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. To keep the game easy to contribute in the future, please improve the code quality.
+
+Requirements:
+- Use a style checker for HTML/CSS/JavaScript.
+- Create an issue with the errors you see in this file and a short description of what needs to be done to remove them.
+- Make sure, you are assigned to the issue.
+- Contribute at least 7 code improvements. Leave the code intact.
+
+Expected Outcome:
+- a merged pull request
+- an issue which you are assigned to
+- in the pull request, a link or text showing that the issues are resolved
+- at least 7 solved code issues
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- Code checkers might be automatically running on this repository. You may use them or suggest others.
+- Do not change generated files such as SVG files or generated CSS/HTML/JS files. Changing them is irrelevant as the mistakes reappear if we edit them with the generator.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [ ] Code
+- [ ] User Interface
+- [ ] Documentation / Training
+- [X] Quality Assurance
+- [ ] Outreach / Research

--- a/tasks/improve-code-quality.md
+++ b/tasks/improve-code-quality.md
@@ -1,3 +1,7 @@
+https://codein.withgoogle.com/dashboard/tasks/5993269697708032/
+
+---
+
 # Labyrinth: Improve the Code Quality
 
 The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. To keep the game easy to contribute in the future, please improve the code quality.

--- a/tasks/solve-an-advanced-issue.md
+++ b/tasks/solve-an-advanced-issue.md
@@ -1,0 +1,29 @@
+
+
+---
+
+# Labyrinth: Solve an advanced Issue
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. Please improve the game by solving an advanced issue.
+
+Requirements:
+- Comment on an [issue](https://github.com/fossasia/labyrinth/labels/advanced) that you want to do it. If you have solved several tasks on this game before, you can not claim tasks that are too easy for you because we need them to give others an easy start.
+- Create a pull request or something that resolves the issue which is tagged as GCI
+- Get assigned to the issue you work on, so other people coordinate with you. Being assigned an issue does not mean you can block progress by not answering.
+
+Expected outcome:
+- The issue is resolved and has a label **advanced**, post a link to it so we can see you were the cause.
+- All issues resulting from your pull-requests are resolved. This is important: You may create new issues and we tend to merge fast and allow several pull requests to be submitted for one issue
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [X] User Interface
+- [X] Documentation / Training
+- [X] Quality Assurance
+- [X] Outreach / Research

--- a/tasks/solve-an-issue.md
+++ b/tasks/solve-an-issue.md
@@ -1,0 +1,29 @@
+https://codein.withgoogle.com/dashboard/tasks/5680981551874048/
+
+---
+
+# Labyrinth: Solve an Issue
+
+The [FOSSASIA Labyrinth](https://github.com/fossasia/labyrinth/) allows you to contribute parts to a huge labyrinth. Please improve the game by solving an issue.
+
+Requirements:
+- Comment on an [issue](https://github.com/fossasia/labyrinth/labels/GCI) that you want to do it. If you have solved several tasks on this game before, you can not claim tasks that are too easy for you because we need them to give others an easy start.
+- Create a pull request or something that resolves the issue which is tagged as GCI
+- Get assigned to the issue you work on, so other people coordinate with you. Being assigned an issue does not mean you can block progress by not answering.
+
+Expected outcome:
+- The issue is resolved, post a link to it so we can see you were the cause.
+- All issues resulting from your pull-requests are resolved. This is important: You may create new issues and we tend to merge fast and allow several pull requests to be submitted for one issue
+
+Hints:
+- If someone wants to work with you, let them do that. You can use techniques like [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) or collaborate together on branches of your forks. You can attribute a pull-request also to other people who helped you out or submit a pull-request where you and an other person contributed together.
+- You can join our [chat on gitter](https://gitter.im/fossasia/labyrinth) if you get stuck to get help or just hang out and have a nice time with others.
+
+---
+
+Categories:
+- [X] Code
+- [X] User Interface
+- [X] Documentation / Training
+- [X] Quality Assurance
+- [X] Outreach / Research


### PR DESCRIPTION
<!-- please summarize the problem you faced -->
The problem I want to solve is
- that we need the GCI tasks somewhere for next year.
- that we can give a good overview over the tasks
- that we can develop and improve the tasks here and move them to GCI later.

<!-- Please summarize the solution you chose -->
My solution for the problem is 
- add all the tasks and the new tasks in this directory

If you like to improve the tasks so you like them better, you can create a pull request to the gci-tasks branch or comment below.
