### PR TITLE
Add tiles to levels file for later use, minor changes to tiles

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -19,4 +19,7 @@ function createTestLevel()
     [door.none, door.top, door.both, door.both, door.both, door.top],
     [NullTile, door.none, door.none, door.none, door.none, door.none],
   ]);
+  /*return new Level([
+    [PlayerStartsAt(door.chessMate),door.chessStale]
+]);*/
 }

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -236,6 +236,10 @@ const door = {
       }
   }),
   chessStale: Object.assign({}, OpenDoors, {
+      canEnterFromTheRight() {return false;},
+      canLeaveToTheRight() {return false;},
+      canEnterFromTheTop: function(player) {return false;},
+      canLeaveToTheTop: function(player) {return false;},
       createImages: function() {
           this.wallTop = this.createImage("tiles/rooms/wall/topChess.svg");
           this.wallRight = this.createImage("tiles/rooms/wall/rightChess.svg");


### PR DESCRIPTION
Added chess tiles made by razetime to levels file for use in the labyrinth, and chess tile behaviour changes done.

This pull request is related to pull request #86 
I modified the labyrinth, you can test my changes here:
http://rawgit.com/razetime/labyrinth/master/index.html
The labyrinth is now working with another level I added in a comment.
