### PR TITLE
Solves #106: Add tiles to actual interface

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -13,8 +13,8 @@ function createTestLevel()
   return new Level([
     [door.none, door.right, door.right, door.right, door.goal, door.none],
     [door.none, door.top, door.both, door.chessMate, door.both, door.chessStale],
-    [door.none, door.top, PlayerStartsAt(door.black), door.both, door.both, door.top],
-    [door.none, door.top, door.both, door.both, door.both, door.top],
+    [door.none, door.top, PlayerStartsAt(door.black), door.green, door.banner, door.top],
+    [door.none, door.top, door.new, door.wheel, door.plain, door.top],
     [door.none, door.top, door.top, door.treasure, door.top, door.top],
     [door.none, door.top, door.both, door.treasureKey, door.drawn, door.top],
     [NullTile, door.none, door.none, door.none, door.none, door.none],

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -342,4 +342,18 @@ const door = {
       this.ground.show();
     },
   }),
+      new: Object.assign({}, OpenDoors, {
+  createImages: function() {
+    this.wallTop = this.createImage("tiles/rooms/door/top.svg");
+    this.wallRight = this.createImage("tiles/rooms/door/right.svg");
+    this.ground = this.createImage("tiles/rooms/floor/new.svg");
+  },
+}),
+plain: Object.assign({}, OpenDoors, {
+createImages: function() {
+  this.wallTop = this.createImage("tiles/rooms/door/top.svg");
+  this.wallRight = this.createImage("tiles/rooms/door/right.svg");
+  this.ground = this.createImage("tiles/rooms/floor/plain.svg");
+},
+}),
 };


### PR DESCRIPTION
This pull request is related to issue #106

I modified the labyrinth, you can test my changes here:
http://rawgit.com/ploypiti/labyrinth/master/index.html

![image](https://user-images.githubusercontent.com/32614202/34518115-756b254c-f0b0-11e7-90f8-eb648a1719e9.png)

The problem I want to solve is **not all added tiles appear when moving to a new level.**
My solution for the problem is **placing unadded tiles in `tiles.js` and `levels.js`**

