### PR TITLE
Fixes #313 : Used text-align center instead of padding in howtoplay.html

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -125,7 +125,7 @@ img {
   font-size: 0.7em;
   text-transform: uppercase;
   text-decoration: none;
-  padding-left: 80px;
+  text-align: center;
 }
 
 .credits a {


### PR DESCRIPTION
### This pull request is related to issue, 
* Fixes #313 

### The problem I want to solve,
* In howtoplay.html, the footer text uses padding instead of text align. 

### My steps to solve it,
* A small change in `css/stylesheet.css`.

### Link
http://rawgit.com/duttaditya1/labyrinth/master/howtoplay.html
