### PR TITLE
Fixes #303: Go through wall

### DIFF
--- a/js/tiles.js
+++ b/js/tiles.js
@@ -714,6 +714,12 @@ const door = {
         },
     }),
     yellow: Object.assign({}, OpenDoors, {
+        canEnterFromTheRight: function(player) {
+            return false;
+        },
+        canLeaveToTheRight: function(player) {
+            return false;
+        },
         createImages: function() {
           this.wallTop = this.createImage("tiles/rooms/door/yellowDoor.svg");
           this.wallRight = this.createImage("tiles/rooms/wall/yellowRight.svg");


### PR DESCRIPTION
Previously the player was able to enter and leave the tile in spite of a wall being there now that bug is fixed