### PR TITLE
Add folder with README and license for CC0 License tiles Fixes #424

### DIFF
--- a/tiles/CC0 license tiles/README.md
+++ b/tiles/CC0 license tiles/README.md
@@ -1,0 +1,14 @@
+# CC0 Licensed tiles
+Add your tile to this folder if it (or its part) is licensed under [Creative Commons CC0 License (also known as Public Domain Dedication)](https://creativecommons.org/publicdomain/zero/1.0/deed.en).
+
+File structure is the same as in `tiles` folder.
+
+For more information check out:
+ - `license.md` file
+ - [Pixabay Terms of Service](https://pixabay.com/en/service/terms/#usage)
+ - [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/legalcode)
+ - [Creative Commons CC0 License (simple language)](https://creativecommons.org/publicdomain/zero/1.0/deed.en)
+
+ ***NOTE:** if you took image/video from [Pixabay](https://pixabay.com/), it's under this license.*
+
+ *Got stuck? Check out [project documentation](https://github.com/fossasia/labyrinth/blob/master/README.md).*

--- a/tiles/CC0 license tiles/license.md
+++ b/tiles/CC0 license tiles/license.md
@@ -1,0 +1,15 @@
+# Creative Commons CC0 License
+
+
+You are free to adapt and use them (images and videos) for commercial purposes without attributing the original author or source. Although not required, a link back to [Pixabay](https://pixabay.com/) is appreciated. [**if that's the source of your image/video**]
+
+Please be aware:
+
+a) Images and Videos may not be used in a way that shows identifiable persons in a disgraceful light, or to imply endorsement of products and services by depicted persons, brands, and organisations - unless permission was granted.
+
+b) Certain Images or Videos may be subject to additional copyrights, property rights, trademarks etc. and may require the consent of a third party or the license of these rights.
+
+***Read more:***
+ - [Pixabay License](https://pixabay.com/en/service/terms/#usage)
+ - [Creative Commons CC0 also known as Public Domain Dedication License](https://creativecommons.org/publicdomain/zero/1.0/legalcode)
+ - [Creative Commons CC0 also known as Public Domain Dedication License (simple language)](https://creativecommons.org/publicdomain/zero/1.0/deed.en)


### PR DESCRIPTION
Add folder with README and license for CC0 License tiles

## Don't delete anything without explicit instructions from a maintainer.
### When you change [things like this in brackets] please remember to delete brackets after you change it.

Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.

- [x] Read and understood [see CONTRIBUTING.md](https://github.com/fossasia/labyrinth/blob/master/CONTRIBUTING.md)
- [ ] Included a Preview link and screenshot showning after and before the changes.
- [x] Included a description of change below.
- [ ] Squashed the commits.

# Changes done in this Pull Request

- Fixes`#424>`

# The problem(s) I want to solve or The facilitie(s) I want to improve is/are,
Add folder for tiles licensed under CC0 License with `license.md` and `README.md`. Fixes #424.

<!-- Please summarize the solution you chose -->
### My steps to solve it,
 - Create proper folder structure for tiles.
 - Create `license.md` file
 - Create `README.md` file

*Please tell me if there is anything else I should include in any of this files so this PR can completely solve an issue.*


