### PR TITLE
Added Black colour on hovering GitHub symbol

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -64,6 +64,7 @@ i.fa.fa-twitter:hover {color: #39aadc;}
 i.fa.fa-youtube-play:hover {color: #ee423d;}
 i.fa.fa-linkedin:hover {color: #81d3fd;}
 i.fa.fa-google-plus:hover {color: #d63d1e;}
+i.fa.fa-github:hover {color:black;}
 
 .waves-effect.waves-light {
   background-color: #60A550;


### PR DESCRIPTION
### Changes done in this Pull Request
On hovering the GitHub symbol the colour of the symbol changes to black colour.

Related Issues or Pull Requests #471 
<!-- please summarise the problem you faced -->
<!-- Please remove unwanted words in following topic -->
### The problem I want to solve or the facility I want to improve is/are
<!-- Mention the bug/facility solved/improved -->
On hovering the GitHub Symbol there was no change of colour.
### My steps to solve it
<!-- Please summarize the solution you chose.
     Mention the files changed. Add what changes you have done. -->
The file changed is css/custom.css 
I have added hover property for GitHub symbol.
Now On hovering the symbol the icon  changes to black colour.
### Screenshots,
<!-- If any -->
Before:
![screen shot 2018-01-13 at 10 42 17 pm](https://user-images.githubusercontent.com/31013104/34908281-0c5e3020-f8b3-11e7-8f75-ac2bd6bef1ea.png)
After:
![screen shot 2018-01-13 at 10 42 37 pm](https://user-images.githubusercontent.com/31013104/34908285-1f4aed18-f8b3-11e7-9f04-7b8b5fc5df19.png)
