### PR TITLE
Fix bugged winter tiles Fixes #494

### DIFF
--- a/js/levels.js
+++ b/js/levels.js
@@ -11,7 +11,7 @@
 function createFirstLevel()
 {
   return new Level("Starter", [
-    [door.none, door.minecraftEntry, door.minecraft, door.winter1, door.goal, door.none],
+    [door.none, door.minecraftEntry, door.minecraft, door.none, door.winter1, door.goal, door.none],
     [door.none, door.orchestra, door.Forbidden, door.chocolate, door.guitarCase, door.winter2],
     [door.none, door.sofa, door.outdoor, door.chessMate, door.texture, door.chessStale],
     [door.drawnbyme, Superhero.art, PlayerStartsAt(door.black), door.green, door.banner, door.threeHeads],

--- a/js/levels.js
+++ b/js/levels.js
@@ -11,8 +11,8 @@
 function createFirstLevel()
 {
   return new Level("Starter", [
-    [door.none, door.minecraftEntry, door.minecraft, door.winter1, door.goal, door.winter2],
-    [door.none, door.orchestra, door.Forbidden, door.chocolate, door.guitarCase, door.none],
+    [door.none, door.minecraftEntry, door.minecraft, door.winter1, door.goal, door.none],
+    [door.none, door.orchestra, door.Forbidden, door.chocolate, door.guitarCase, door.winter2],
     [door.none, door.sofa, door.outdoor, door.chessMate, door.texture, door.chessStale],
     [door.drawnbyme, Superhero.art, PlayerStartsAt(door.black), door.green, door.banner, door.threeHeads],
     [door.none, door.highLow, door.new, door.wheel, door.plain, door.top],

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -781,10 +781,10 @@ const door = {
     }),
     minecraft: Object.assign({}, OpenDoors, {
         canEnterFromTheRight() {
-            return false;
+            return true;
         },
         canLeaveToTheRight() {
-            return false;
+            return true;
         },
         createImages: function() {
             this.wallTop = this.createImage("tiles/rooms/wall/topMinecraft.svg");
@@ -1005,13 +1005,25 @@ const door = {
         canEnterFromTheRight: function(player) {
             return false;
         },
+        canEnterFromTheLeft: function(player) {
+            return true;
+        },
         canLeaveToTheRight: function(player) {
             return false;
+        },
+        canLeaveToTheBottom: function(player) {
+            return false;
+        },
+        canLeaveToTheLeft: function(player) {
+            return true;
+        },
+        canLeaveToTheTop: function(player) {
+            return true;
         },
         createImages: function() {
           this.wallTop = this.createImage("tiles/rooms/door/top.svg");
           this.wallRight = this.createImage("tiles/rooms/wall/right.svg");
-          this.ground = this.createImage("tiles/rooms/floor/winter1.svg");
+          this.ground = this.createImage("tiles/animations/winter1.svg");
         },
         visit: function() {
           playAudio("jingleBellsKuba.mp3");
@@ -1025,7 +1037,19 @@ const door = {
         canEnterFromTheRight: function(player) {
             return false;
         },
+        canEnterFromTheBottom: function(player) {
+            return false;
+        },
+        canEnterFromTheLeft: function(player) {
+            return true;
+        },
         canLeaveToTheRight: function(player) {
+            return false;
+        },
+        canLeaveToTheLeft: function(player) {
+            return true;
+        },
+        canLeaveToTheBottom: function(player) {
             return false;
         },
         createImages: function() {

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -781,10 +781,10 @@ const door = {
     }),
     minecraft: Object.assign({}, OpenDoors, {
         canEnterFromTheRight() {
-            return true;
+            return false;
         },
         canLeaveToTheRight() {
-            return true;
+            return false;
         },
         createImages: function() {
             this.wallTop = this.createImage("tiles/rooms/wall/topMinecraft.svg");
@@ -1005,16 +1005,10 @@ const door = {
         canEnterFromTheRight: function(player) {
             return false;
         },
-        canEnterFromTheLeft: function(player) {
-            return true;
-        },
         canLeaveToTheRight: function(player) {
             return false;
         },
         canLeaveToTheBottom: function(player) {
-            return false;
-        },
-        canLeaveToTheLeft: function(player) {
             return true;
         },
         canLeaveToTheTop: function(player) {
@@ -1044,7 +1038,7 @@ const door = {
             return true;
         },
         canLeaveToTheRight: function(player) {
-            return false;
+            return true;
         },
         canLeaveToTheLeft: function(player) {
             return true;

--- a/tiles/animations/winter1.svg
+++ b/tiles/animations/winter1.svg
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<script>
-  @keyframes winterAnimation {
-    50% { transform: scale(1.5, 1.5); }
-  }
-  #svg2 {
-    animation: winterAnimation 4s infinite linear;
-  }
-</script>
 
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"


### PR DESCRIPTION
- [x] Read and understood [see CONTRIBUTING.md](https://github.com/fossasia/labyrinth/blob/master/CONTRIBUTING.md)
- [x] Included a preview link and screenshot showing after and before the changes.
- [x] Included a description of change below.
- [ ] Squashed the commits.

### Changes done in this Pull Request

- If your change will be reflected on the website, please provide a **Test-Link**
  https://kubami9.github.io/labyrinth-km-contribute/

  Fixes #494

### The problem I want to solve or the facility I want to improve is/are
Fixed winter landscape. Enabled moving in proper directions and changed `winter2` tile place. Also fixed broken SVG. I'm going to add animation to it in the next PR.

### My steps to solve it
Enabled moving in right direction from minecraft tile and enabled proper directions in winter tiles. Deleted code braking svg file which I previously added by mistake.

### Screenshots, (winter tiles marked with the red circles)
![pr_screen](https://user-images.githubusercontent.com/16598854/34916115-cb6a1932-f932-11e7-8cc0-fd817fc9bc15.png)




