### PR TITLE
Fix player coming above alert boxes

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -257,7 +257,7 @@ nav .left li a {
 
 #player {
   position: absolute;
-  z-index: 10000;
+  z-index: 1;
   width: 55px;
   height: 60px;
 }


### PR DESCRIPTION
<!-- Don't delete anything without explicit instructions from a maintainer. -->

<!-- Check by changing each `[ ]` to `[x]`. Please take note of the whitespace as it matters. -->
- [x] Read and understood [see CONTRIBUTING.md](https://github.com/fossasia/labyrinth/blob/master/CONTRIBUTING.md)
- [x] Included a preview link and screenshot showing after and before the changes.
- [x] Included a description of change below.
- [x] Squashed the commits.

### Changes done in this Pull Request

- If your change will be reflected on the website, please provide a **Test-Link**
  <!-- Here you can add your preview link. Please replace "USERNAME" with your GitHub username 
       and "master" with the branch you are working on. -->
  https://vsvipul.github.io/labyrinth/

- <!-- If you fully fixed some issue(s), 
please insert the issue number after the #.
If you have not fixed some issue(s) completely but only some of the step(s) in issue then remove “Fixes #” and please mention the related issue number(s) along with the step number(s). -->
  Fixes #341 and point 11 of #206  


<!-- please summarize the problem you faced -->
<!-- Please remove unwanted words in following topic -->
### The problem I want to solve or the facility I want to improve is/are that player was overlapping the alert dialog. 
<!-- Mention the bug/facility solved/improved -->

### My steps to solve it
<!-- Please summarize the solution you chose.
     Mention the files changed. Add what changes you have done. -->
I changed the z- index in the css file to do so.

### Screenshots,
<!-- If any -->
![screenshot from 2018-01-15 00-40-30](https://user-images.githubusercontent.com/21038781/34919647-7cd3c308-f98d-11e7-9b7c-67a3a2df45f1.png)


