### PR TITLE
Added colour to be given to hovered tabs within menu tabs UI_Identity.md

### DIFF
--- a/UI_Identity.md
+++ b/UI_Identity.md
@@ -30,6 +30,7 @@
 - **Sidebar BG** #84C79F
 - **Sidebar text** #fff
 - **Blank inventory BG & sidebar border** #23AF92
+- **Hovered tabs within Menu tabs** rgba(0,0,0,0.2)
 
 ---
 


### PR DESCRIPTION

### Changes done in this Pull Request
Added Colour to be given to hovered tabs within menu tabs.
  Fixes #625 
### The problem I want to solve or the facility I want to improve is/are
The colour to be used for hovered tabs within the menu tabs was not specified.
### My steps to solve it
Mentioned the coloured to be used.
Files Changed UI_Identity.md
### Screenshot
Before:
![screen shot 2018-01-23 at 5 00 57 pm](https://user-images.githubusercontent.com/31013104/35273527-e44a92f0-005e-11e8-8680-3a2ef497eb2c.png)
After:
![screen shot 2018-01-23 at 5 00 05 pm](https://user-images.githubusercontent.com/31013104/35273542-ede2c5bc-005e-11e8-9aeb-c6bf93547800.png)

