### PR TITLE
Fixes #785 : Update Readme Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/fossasia/labyrinth.svg)](http://isitmaintained.com/project/fossasia/labyrinth "Percentage of issues still open")
 [![license](https://img.shields.io/github/license/fossasia/labyrinth.svg)](LICENSE)
 
-[**Play Now**](http://labyrinth-live.surge.sh/) |
-[**Learn How to Play**](http://lsppublicschool.org/projectx/labyrinth/howtoplay.html) |
-[**Documentation**](http://www.lsppublicschool.org/projectx/labyrinth/documentation/)
+[**Play Now**](http://labyrinth-game.surge.sh/) |
+[**Learn How to Play**](http://labyrinth-game.surge.sh/howtoplay.html) |
+[**Documentation**](http://labyrinth-game.surge.sh/documentation/)
 
 ## Content Outline
 - [**Motivation**](#motivation)


### PR DESCRIPTION
## UPDATE

# ***http://labyrinth-game.surge.sh***
Updating readme links to serve game from http://labyrinth-game.surge.sh


<!-- Check by changing each `[ ]` to `[x]`. Please take note of the whitespace as it matters. -->
- [x] Read and understood [see CONTRIBUTING.md](https://github.com/fossasia/labyrinth/blob/master/CONTRIBUTING.md)
- [x] Included a preview link and screenshot showing after and before the changes.
- [x] Included a description of change below.
- [x] [squashed the commits][squash].

### Changes done in this Pull Request
- On every new PR, travis clones the latest repo and serves it on http://labyrinth-game.surge.sh
- Updates the game from latest version on every PR.


- Fixes #785 Readme links outdated




[squash]: https://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git
