### PR TITLE
adding ci reporter

### DIFF
--- a/.github/ci-reporter.yml
+++ b/.github/ci-reporter.yml
@@ -1,0 +1,8 @@
+# Set to false to create a new comment instead of updating the app's first one
+updateComment: true
+
+# Use a custom string, or set to false to disable
+before: "✨ Good work on this PR so far! ✨ Unfortunately, the [ build]() is failing as of . Here's the output:"
+
+# Use a custom string, or set to false to disable
+after: "I'm sure you can fix it! If you need help, don't hesitate to ask a maintainer of the project!"


### PR DESCRIPTION
ADDING CI Reporter
```
# Set to false to create a new comment instead of updating the app's first one
updateComment: true

# Use a custom string, or set to false to disable
before: "✨ Good work on this PR so far! ✨ Unfortunately, the [ build]() is failing as of . Here's the output:"

# Use a custom string, or set to false to disable
after: "I'm sure you can fix it! If you need help, don't hesitate to ask a maintainer of the project!"
```