### PR TITLE
Add documentation for switching levels and goal tile

### DIFF
--- a/documentation/data.json
+++ b/documentation/data.json
@@ -34,6 +34,14 @@
 			"github" : "fossasia/labyrinth/",
 			"file" : "adding-new-badge.html",
 			"slug" : "API-Adding-New-Badge" 			
-		}
+		},
+		{
+           "itemName":"Adding and Switching Levels",
+           "author" : "Labyrinth Team",
+           "github" : "fossasia/labyrinth/",
+           "file" : "adding-new-level.html",
+           "slug" : "API-Adding-New-Level"
+        }
+
 	]
 }

--- a/documentation/storage/adding-new-level.html
+++ b/documentation/storage/adding-new-level.html
@@ -1,0 +1,37 @@
+<h1>Adding and Switching Levels</h1>
+
+<p>
+This document explains how to add a new level in Labyrinth
+and how to switch between different levels during the game.
+</p>
+
+<h2>Understanding Levels</h2>
+<p>
+A level in Labyrinth defines the layout of tiles, paths, and the goal.
+Each level is created using existing tile definitions and configurations.
+Before adding a new level, it is recommended to review an existing level
+to understand the structure.
+</p>
+
+<h2>Adding a New Level</h2>
+<ul>
+  <li>Locate an existing level configuration in the project.</li>
+  <li>Copy an existing level to use it as a template.</li>
+  <li>Modify the layout and tiles according to the new level design.</li>
+  <li>Save the new level configuration.</li>
+</ul>
+
+<h2>Switching Between Levels</h2>
+<p>
+To switch between levels, update the level reference used when the game
+is initialized. The game loads the selected level configuration
+when it starts or when a level change is triggered.
+</p>
+
+<h2>Adding a Goal Tile</h2>
+<ul>
+  <li>Locate an existing goal tile definition in the project.</li>
+  <li>Ensure that only one goal tile is placed in a level.</li>
+  <li>Position the goal tile at the desired target location.</li>
+  <li>The level is completed when the player reaches the goal tile.</li>
+</ul>

--- a/documentation/storage/adding-new-level.html
+++ b/documentation/storage/adding-new-level.html
@@ -7,31 +7,67 @@ and how to switch between different levels during the game.
 
 <h2>Understanding Levels</h2>
 <p>
-A level in Labyrinth defines the layout of tiles, paths, and the goal.
-Each level is created using existing tile definitions and configurations.
-Before adding a new level, it is recommended to review an existing level
-to understand the structure.
+Levels in Labyrinth are defined inside <code>/js/levels.js</code>.
+Each level is created using the <code>new Level("LevelName", [...])</code> constructor,
+where the second argument is a two-dimensional array representing the layout of tiles.
+</p>
+
+<p>
+Each row in the array represents a row of tiles in the level.
+Each element inside the row refers to a specific tile definition
+(such as <code>door.goal</code>, <code>forest.top</code>, etc.).
 </p>
 
 <h2>Adding a New Level</h2>
 <ul>
-  <li>Locate an existing level configuration in the project.</li>
-  <li>Copy an existing level to use it as a template.</li>
-  <li>Modify the layout and tiles according to the new level design.</li>
-  <li>Save the new level configuration.</li>
+  <li>Open <code>/js/levels.js</code>.</li>
+  <li>Locate an existing level function such as <code>createFirstLevel()</code> or <code>createAdvancedLevel()</code>.</li>
+  <li>Copy an existing level function and rename it (for example, <code>createMyNewLevel()</code>).</li>
+  <li>Modify the 2D tile array to design your new level layout.</li>
+  <li>Ensure that a starting tile is defined using <code>PlayerStartsAt(theme.start)</code> or a similar start tile.</li>
+  <li>Save the file after making changes.</li>
 </ul>
 
 <h2>Switching Between Levels</h2>
 <p>
-To switch between levels, update the level reference used when the game
-is initialized. The game loads the selected level configuration
-when it starts or when a level change is triggered.
+To switch between levels, update the level creation reference used when initializing the game.
+Levels are loaded through functions defined in <code>/js/levels.js</code>.
+</p>
+
+<p>
+For example, if the game currently uses:
+</p>
+
+<pre>
+createFirstLevel()
+</pre>
+
+<p>
+You can switch to another level by replacing it with:
+</p>
+
+<pre>
+createAdvancedLevel()
+</pre>
+
+<p>
+This change is typically done in the game initialization logic
+(for example, inside <code>/js/gui.js</code>).
+The selected level function determines which tile configuration
+is loaded when the game starts.
 </p>
 
 <h2>Adding a Goal Tile</h2>
 <ul>
-  <li>Locate an existing goal tile definition in the project.</li>
-  <li>Ensure that only one goal tile is placed in a level.</li>
-  <li>Position the goal tile at the desired target location.</li>
-  <li>The level is completed when the player reaches the goal tile.</li>
+  <li>Goal tiles are defined inside <code>/js/levels.js</code> as part of the level’s 2D array.</li>
+  <li>Depending on the theme, a goal tile may appear as <code>door.goal</code>, <code>food.end</code>, <code>dark.end</code>, or similar.</li>
+  <li>Place the goal tile at the desired position inside the level array.</li>
+  <li>The level is considered complete when the player reaches the goal tile.</li>
 </ul>
+
+<p>
+The engine does not strictly enforce having exactly one goal tile.
+If multiple goal tiles are added, all of them will be placed in the level.
+If no goal tile is defined, the level may not complete as expected.
+Therefore, it is recommended to include exactly one goal tile per level.
+</p>


### PR DESCRIPTION
Fixes #547

This PR adds documentation explaining how to add a new level,
switch between levels, and define a goal tile.

## Summary by Sourcery

Add new documentation page describing how to add levels, switch between them, and configure a goal tile in the Labyrinth game.

Documentation:
- Document the concepts of levels in Labyrinth and how they define layout and goals.
- Add step-by-step guidance for creating a new level configuration.
- Describe how to switch the active level used by the game.
- Explain how to define and position a goal tile and when a level is considered complete.